### PR TITLE
added backward compatible interface

### DIFF
--- a/modules/core/keeper/keeper.go
+++ b/modules/core/keeper/keeper.go
@@ -9,6 +9,8 @@ import (
 	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
+	ibcdmtypes "github.com/cosmos/ibc-go/v3/modules/light-clients/01-dymint/types"
+
 	clientkeeper "github.com/cosmos/ibc-go/v3/modules/core/02-client/keeper"
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	connectionkeeper "github.com/cosmos/ibc-go/v3/modules/core/03-connection/keeper"
@@ -36,8 +38,19 @@ type Keeper struct {
 	Router           *porttypes.Router
 }
 
-// NewKeeper creates a new ibc Keeper
+//IBCKeeper initialized in wasm code (in wasmd@v0.28.0/x/wasm/keeper/test_common.go:354)
+//We need to maintain backward comptabile interface
 func NewKeeper(
+	cdc codec.BinaryCodec, key sdk.StoreKey, paramSpace paramtypes.Subspace,
+	stakingKeeper clienttypes.StakingKeeper, upgradeKeeper clienttypes.UpgradeKeeper,
+	scopedKeeper capabilitykeeper.ScopedKeeper,
+) *Keeper {
+	//Using dymint and nil as default. we can panic instead
+	return NewKeeperWithSelfClient(cdc, key, paramSpace, stakingKeeper, upgradeKeeper, scopedKeeper, ibcdmtypes.NewSelfClient(), nil)
+}
+
+// NewKeeper creates a new ibc Keeper
+func NewKeeperWithSelfClient(
 	cdc codec.BinaryCodec, key sdk.StoreKey, paramSpace paramtypes.Subspace,
 	stakingKeeper clienttypes.StakingKeeper, upgradeKeeper clienttypes.UpgradeKeeper,
 	scopedKeeper capabilitykeeper.ScopedKeeper, selfClient exported.SelfClient, clientHooks exported.ClientHooks,

--- a/modules/core/keeper/keeper_test.go
+++ b/modules/core/keeper/keeper_test.go
@@ -64,7 +64,7 @@ func (suite *KeeperTestSuite) TestNewKeeper() {
 		upgradeKeeper clienttypes.UpgradeKeeper
 		scopedKeeper  capabilitykeeper.ScopedKeeper
 		newIBCKeeper  = func() {
-			ibckeeper.NewKeeper(
+			ibckeeper.NewKeeperWithSelfClient(
 				suite.chainA.GetSimApp().AppCodec(),
 				suite.chainA.GetSimApp().GetKey(ibchost.StoreKey),
 				suite.chainA.GetSimApp().GetSubspace(ibchost.ModuleName),

--- a/testing/simapp/app.go
+++ b/testing/simapp/app.go
@@ -347,7 +347,7 @@ func NewSimAppWithConsensusType(
 		panic(fmt.Sprintf("client type %s is not supported", chainConsensusType))
 	}
 	// Create IBC Keeper
-	app.IBCKeeper = ibckeeper.NewKeeper(
+	app.IBCKeeper = ibckeeper.NewKeeperWithSelfClient(
 		appCodec, keys[ibchost.StoreKey], app.GetSubspace(ibchost.ModuleName), app.StakingKeeper, app.UpgradeKeeper, scopedIBCKeeper, selfClient, nil,
 	)
 


### PR DESCRIPTION
Unfortunately, wasm lib uses IBCKeeper internally,
which means we need to maintain backward comptabile interface.

while this wasm code relates to testing (and probably won't be called) it still needs the correct interface to compile.